### PR TITLE
Update classifier with changes in VRO and from progressive rollout

### DIFF
--- a/src/python_src/api.py
+++ b/src/python_src/api.py
@@ -37,10 +37,7 @@ app = FastAPI(
 
 
 @app.middleware("http")
-async def save_process_time_as_metric(
-    request: Request,
-    call_next: Callable[[Request], Awaitable[Response]]
-) -> Response:
+async def save_process_time_as_metric(request: Request, call_next: Callable[[Request], Awaitable[Response]]) -> Response:
     start_time = time.time()
     response = await call_next(request)
     process_time = time.time() - start_time
@@ -103,21 +100,5 @@ def va_gov_claim_classifier(claim: VaGovClaim, request: Request) -> ClassifierRe
 
 
 @app.post("/expanded-contention-classification")
-@log_claim_stats_decorator
-def expanded_classifications(claim: VaGovClaim, request: Request) -> ClassifierResponse:
-    classified_contentions = []
-    for contention in claim.contentions:
-        classification = classify_contention(contention, claim, request)
-        classified_contentions.append(classification)
-
-    num_classified = len([c for c in classified_contentions if c.classification_code])
-
-    response = ClassifierResponse(
-        contentions=classified_contentions,
-        claim_id=claim.claim_id,
-        form526_submission_id=claim.form526_submission_id,
-        is_fully_classified=num_classified == len(classified_contentions),
-        num_processed_contentions=len(classified_contentions),
-        num_classified_contentions=num_classified,
-    )
-    return response
+def expanded_classifications(claim: VaGovClaim, request: Request) -> Dict[str, str]:
+    return {"message": "New classification method in development; endpoint is not currently available"}

--- a/src/python_src/util/classifier_utilities.py
+++ b/src/python_src/util/classifier_utilities.py
@@ -7,10 +7,9 @@ from ..pydantic_models import (
     Contention,
     VaGovClaim,
 )
-from .app_utilities import dc_lookup_table, dropdown_lookup_table, expanded_lookup_table
+from .app_utilities import dc_lookup_table, expanded_lookup_table
 from .expanded_lookup_table import ExpandedLookupTable
 from .logging_utilities import log_contention_stats_decorator
-from .lookup_table import ContentionTextLookupTable
 
 
 @runtime_checkable
@@ -19,8 +18,7 @@ class LookupTable(Protocol):
 
 
 def get_classification_code_name(
-    contention: Contention,
-    lookup_table: LookupTable
+    contention: Contention, lookup_table: LookupTable
 ) -> Tuple[Optional[int], Optional[str], str]:
     """
     check contention type and match contention to appropriate table's
@@ -64,16 +62,10 @@ def get_classification_code_name(
 
 
 @log_contention_stats_decorator
-def classify_contention(
-    contention: Contention,
-    claim: VaGovClaim,
-    request: Request
-) -> Tuple[ClassifiedContention, str]:
-    lookup_table: Union[ExpandedLookupTable, ContentionTextLookupTable]
-    if request.url.path == "/expanded-contention-classification":
+def classify_contention(contention: Contention, claim: VaGovClaim, request: Request) -> Tuple[ClassifiedContention, str]:
+    lookup_table: Union[ExpandedLookupTable]
+    if request.url.path == "/va-gov-claim-classifier":
         lookup_table = expanded_lookup_table
-    else:
-        lookup_table = dropdown_lookup_table
 
     classification_code, classification_name, classified_by = get_classification_code_name(contention, lookup_table)
 

--- a/src/python_src/util/expanded_lookup_table.py
+++ b/src/python_src/util/expanded_lookup_table.py
@@ -94,6 +94,43 @@ class ExpandedLookupTable:
 
         return text.lower().strip()
 
+    def _remove_parenthetical_terms(self, text: str) -> List[str]:
+        """
+        Removes terms within contention text values that are included in parenthetical. This will append the
+        rest of the string to the parenthetical, and create a list of terms from this.
+
+        Ex: "degenerative arthritis (osteoarthritis) in wrist, right" will return
+            ["osteoarthritis in wrist, right", "degenerative arthritis in wrist, right"]
+
+        This will then move through the removal pipeline to build the lookup table.
+        """
+        parenthetical_terms = re.findall(r"\((.*?)\)", text)
+        base_text = re.sub(r"\(.*?\)", "", text)
+        variations = [re.sub(r"\(.*?\)", "", f"{term} {text.split(term)[-1]}") for term in parenthetical_terms]
+        variations.append(base_text)
+        return [self._removal_pipeline(v) for v in variations]
+
+    def _add_to_lut(
+        self,
+        key: str,
+        row: Dict[str, str],
+        classification_code_mappings: Dict[FrozenSet[str], Dict[str, Union[str, int]]],
+    ) -> None:
+        """
+        Adds a processed key and corresponding classification data to the lookup table.
+        Args:
+            key (str): The string key to process and add.
+            row (dict): A row from the CSV containing classification data.
+            classification_code_mappings (dict): The lookup table to update.
+        """
+        processed_key = self._removal_pipeline(key)
+        if processed_key != "":
+            processed_lookup_key: FrozenSet[str] = frozenset(self._removal_pipeline(key).split())
+            classification_code_mappings[processed_lookup_key] = {
+                "classification_code": int(row[self.init_values.classification_code]),
+                "classification_name": row[self.init_values.classification_name],
+            }
+
     def _build_lut(self) -> Dict[FrozenSet[str], Dict[str, Union[str, int]]]:
         """
         Builds the lookup table using the CSV file
@@ -105,25 +142,11 @@ class ExpandedLookupTable:
         for row in csv_rows:
             key_text = self.init_values.input_key
             if "(" in row[key_text]:
-                parenthetical_terms = re.findall(r"\((.*?)\)", row[key_text])
-                ls_terms = [term for term in parenthetical_terms]
-                removed_parenthetical = [re.sub(r"\(.*?\)", "", row[key_text])]
-                ls_terms.extend(removed_parenthetical)
-                for t in ls_terms:
-                    k = self._removal_pipeline(t)
-                    if k != "":
-                        term_set: FrozenSet[str] = frozenset(k.split())
-                        classification_code_mappings[term_set] = {
-                            "classification_code": int(row[self.init_values.classification_code]),
-                            "classification_name": row[self.init_values.classification_name],
-                        }
+                ls_terms = self._remove_parenthetical_terms(row[key_text])
+                for term in ls_terms:
+                    self._add_to_lut(term, row, classification_code_mappings)
             # adds the original string
-            k = self._removal_pipeline(row[key_text])
-            original_set: FrozenSet[str] = frozenset(k.split())
-            classification_code_mappings[original_set] = {
-                "classification_code": int(row[self.init_values.classification_code]),
-                "classification_name": row[self.init_values.classification_name],
-            }
+            self._add_to_lut(row[key_text], row, classification_code_mappings)
         # adds the joint lookup to the table
         classification_code_mappings.update(self._musculoskeletal_lookup())
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -31,4 +31,4 @@ def test_build_expanded_table() -> None:
         common_words=app_config["common_words"],
         musculoskeletal_lut=app_config["musculoskeletal_lut"],
     )
-    assert len(expanded.contention_text_lookup_table) == 1017
+    assert len(expanded.contention_text_lookup_table) == 1037

--- a/tests/test_expanded_lookup.py
+++ b/tests/test_expanded_lookup.py
@@ -203,7 +203,7 @@ def test_api_endpoint(test_client: TestClient) -> None:
             },
         ],
     }
-    response = test_client.post("/expanded-contention-classification", json=json_post_data)
+    response = test_client.post("/va-gov-claim-classifier", json=json_post_data)
     assert response.status_code == 200
     assert response.json() == {
         "contentions": [
@@ -298,3 +298,14 @@ def test_parenthetical_removal_specific_terms() -> None:
     ]
     assert isinstance(TEST_LUT._remove_parenthetical_terms(test_str), list)
     assert TEST_LUT._remove_parenthetical_terms(test_str) == expected
+
+
+def test_expanded_endpoint_not_in_use(test_client: TestClient) -> None:
+    json_body = {
+        "claim_id": 100,
+        "form526_submission_id": 500,
+        "contentions": [{"contention_text": "osteoarthritis in ankle", "contention_type": "NEW", "diagnostic_code": "1234"}],
+    }
+    response = test_client.post("/expanded-contention-classification", json=json_body)
+    assert response.status_code == 200
+    assert response.json() == {"message": "New classification method in development; endpoint is not currently available"}

--- a/tests/test_expanded_lookup.py
+++ b/tests/test_expanded_lookup.py
@@ -262,3 +262,39 @@ def test_api_endpoint(test_client: TestClient) -> None:
         "num_processed_contentions": 8,
         "num_classified_contentions": 6,
     }
+
+
+def test_removed_terms_not_in_lut() -> None:
+    removed_terms = ["osteoarthritis", "tendinitis", "difficulty swallowing"]
+    for term in removed_terms:
+        assert TEST_LUT.get(term) == {
+            "classification_code": None,
+            "classification_name": None,
+        }
+
+
+def test_parenthetical_removal_normal() -> None:
+    test_str = "ACL tear (anterior cruciate ligament tear), bilateral"
+    expected = ["anterior cruciate ligament tear", "acl tear"]
+    assert isinstance(TEST_LUT._remove_parenthetical_terms(test_str), list)
+    assert TEST_LUT._remove_parenthetical_terms(test_str) == expected
+
+
+def test_parenthetical_removal_multiple() -> None:
+    """
+    There are currently no terms in the CSV that have multiple parenthetical values
+    """
+    test_str = "knee replacement (knee arthroplasty) (knee joint replacement), bilateral"
+    expected = ["knee arthroplasty", "knee joint replacement", "knee replacement"]
+    assert isinstance(TEST_LUT._remove_parenthetical_terms(test_str), list)
+    assert TEST_LUT._remove_parenthetical_terms(test_str) == expected
+
+
+def test_parenthetical_removal_specific_terms() -> None:
+    test_str = "degenerative arthritis (osteoarthritis) in wrist, right"
+    expected = [
+        "osteoarthritis wrist",
+        "degenerative arthritis wrist",
+    ]
+    assert isinstance(TEST_LUT._remove_parenthetical_terms(test_str), list)
+    assert TEST_LUT._remove_parenthetical_terms(test_str) == expected


### PR DESCRIPTION
This update captures code changes that were released in VRO to fix a bug identified in the expanded classification methods.  This adds helper functions to correctly handle parenthetical terms that are in our classification code mappings.  

The progressive rollout for the new classification method was completed on Jan 16 and all claims are being routed to this method.  To update this repo for release during the migration process, this also updates the classifier utility functions to use the expanded classification method for the `/va-gov-claim-classifier` endpoint and removes the logic for the expanded classification endpoint.  Because we are working with the VA CAIO team to build an ML model to provide classification, I left the expanded-classification-endpoint that will be used to test this method when the model building process is completed.  