### PR TITLE
feat: add staging environment to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
         description: 'Environment to deploy to'
         options:
           - dev
+          - staging
   workflow_run:
     workflows:
       - 'Build and push to ECR'
@@ -17,7 +18,7 @@ on:
       - completed
 
 env:
-  auto_deploy_envs: 'dev'
+  auto_deploy_envs: 'dev staging'
 
 concurrency:
   group: release-${{ github.ref }}


### PR DESCRIPTION
- Updated `.github/workflows/release.yml` to include `staging` as a deployment option.
- Modified `auto_deploy_envs` to support both `dev` and `staging`.

This change enables automated deployments to the staging environment.

GH issue: https://github.com/department-of-veterans-affairs/abd-vro/issues/4044

Ref: https://github.com/department-of-veterans-affairs/disability-max-ratings-api/pull/99/