### PR TITLE
Updates Expanded Lookup Table to handle parenthetical terms

### DIFF
--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -31,4 +31,4 @@ def test_build_expanded_table() -> None:
         common_words=app_config["common_words"],
         musculoskeletal_lut=app_config["musculoskeletal_lut"],
     )
-    assert len(expanded.contention_text_lookup_table) == 1017
+    assert len(expanded.contention_text_lookup_table) == 1037

--- a/tests/test_expanded_lookup.py
+++ b/tests/test_expanded_lookup.py
@@ -262,3 +262,39 @@ def test_api_endpoint(test_client: TestClient) -> None:
         "num_processed_contentions": 8,
         "num_classified_contentions": 6,
     }
+
+
+def test_removed_terms_not_in_lut() -> None:
+    removed_terms = ["osteoarthritis", "tendinitis", "difficulty swallowing"]
+    for term in removed_terms:
+        assert TEST_LUT.get(term) == {
+            "classification_code": None,
+            "classification_name": None,
+        }
+
+
+def test_parenthetical_removal_normal() -> None:
+    test_str = "ACL tear (anterior cruciate ligament tear), bilateral"
+    expected = ["anterior cruciate ligament tear", "acl tear"]
+    assert isinstance(TEST_LUT._remove_parenthetical_terms(test_str), list)
+    assert TEST_LUT._remove_parenthetical_terms(test_str) == expected
+
+
+def test_parenthetical_removal_multiple() -> None:
+    """
+    There are currently no terms in the CSV that have multiple parenthetical values
+    """
+    test_str = "knee replacement (knee arthroplasty) (knee joint replacement), bilateral"
+    expected = ["knee arthroplasty", "knee joint replacement", "knee replacement"]
+    assert isinstance(TEST_LUT._remove_parenthetical_terms(test_str), list)
+    assert TEST_LUT._remove_parenthetical_terms(test_str) == expected
+
+
+def test_parenthetical_removal_specific_terms() -> None:
+    test_str = "degenerative arthritis (osteoarthritis) in wrist, right"
+    expected = [
+        "osteoarthritis wrist",
+        "degenerative arthritis wrist",
+    ]
+    assert isinstance(TEST_LUT._remove_parenthetical_terms(test_str), list)
+    assert TEST_LUT._remove_parenthetical_terms(test_str) == expected


### PR DESCRIPTION
This moves functionality from the VRO repo that properly handles parenthetical terms correctly.  This code has previously been reviewed in the VRO repo and is just moving this over to keep this code up to date.  