### PR TITLE
Updates to build and push to ECR workflow

### DIFF
--- a/.github/workflows/build_and_push_to_ecr.yml
+++ b/.github/workflows/build_and_push_to_ecr.yml
@@ -5,6 +5,10 @@ on:
   push:
     branches:
       - main
+  schedule:
+    # Run every day at midnight UTC - this is a workaround to ensure the workflow is run at least once per day since
+    # VA GitHub enterprise settings prevent github actions from running as a result of dependabot PRs.
+    - cron: '0 0 * * *'
 
 concurrency:
   group: build-and-push-${{ github.ref }}
@@ -33,6 +37,17 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v2
         with:
           mask-password: 'true'
+
+      - name: Check if image already exists in ECR
+        id: check-image
+        run: |
+          if aws ecr describe-images --repository-name ${{ secrets.ECR_REPOSITORY }} --image-ids imageTag=${{ github.sha }} >/dev/null 2>&1; then
+            echo "Image with tag ${{ github.sha }} already exists in ECR."
+            echo "::warning::Image already exists in ECR, stopping build workflow with error status to prevent release workflow from running."
+            exit 1
+          else
+            echo "Image does not exist in ECR, proceeding with build"
+          fi
 
       - name: Build Docker Image And Push to ECR
         uses: docker/build-push-action@v6


### PR DESCRIPTION
Prevent build and push to ECR if image tag already exists. Run cron job to keep images in ECR fresh as a workaround to dependabot not triggering this workflow