### PR TITLE
Add logging attribute 'ml_sample' to capture inputs that the csv lookup fails to classify 

### DIFF
--- a/src/python_src/util/logging_utilities.py
+++ b/src/python_src/util/logging_utilities.py
@@ -54,7 +54,7 @@ def log_expanded_contention_text(
         )
     # log none as the processed text if it is not in the LUT and leave unmapped contention text as is
     else:
-        logging_dict.update({"processed_contention_text": None})
+        logging_dict.update({"processed_contention_text": None, "ml_sample": processed_text})
 
     return logging_dict
 
@@ -68,7 +68,7 @@ def log_contention_stats(
 ) -> None:
     """
     Logs stats about each contention process by the classifier. This will maintain
-    compatability with the existing datadog widgets.
+    compatibility with the existing datadog widgets.
     """
     classification_code = classified_contention.classification_code or None
     classification_name = classified_contention.classification_name or None

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -155,6 +155,7 @@ def test_non_classified_contentions(mocked_func: Mock) -> None:
         "endpoint": "/expanded-contention-classification",
         "processed_contention_text": None,
         "classification_method": classified_by,
+        "ml_sample": "john acl tear",
     }
     mocked_func.assert_called_once_with(expected_log)
 
@@ -280,6 +281,7 @@ def test_contentions_with_pii(mocked_func: Mock) -> None:
             "endpoint": "/expanded-contention-classification",
             "processed_contention_text": None,
             "classification_method": classified_by,
+            "ml_sample": "dependent claim child",
         },
         {
             "vagov_claim_id": test_claim.claim_id,
@@ -294,6 +296,7 @@ def test_contentions_with_pii(mocked_func: Mock) -> None:
             "endpoint": "/expanded-contention-classification",
             "processed_contention_text": None,
             "classification_method": classified_by,
+            "ml_sample": "john doe acl tear",
         },
     ]
 
@@ -406,6 +409,7 @@ def test_full_logging_expanded_endpoint(mocked_func: Mock) -> None:
             "endpoint": "/expanded-contention-classification",
             "classification_method": classified_by,
             "processed_contention_text": None,
+            "ml_sample": "john doe acl tear",
         },
         {
             "vagov_claim_id": test_claim.claim_id,


### PR DESCRIPTION
## summary of changes

Introduces attribute `ml_sample` (machine learning sample) to the log message for cases where the csv lookup was unable to return a classification.

From these samples, we would like to see the predictions from the ML classifier. This data (ML classifier's performance against these inputs that the csv lookup is known to fail on) will inform how to incorporate the ML classifier in order to boost overall accuracy, as described in https://github.com/department-of-veterans-affairs/vagov-claim-classification/issues/776 .


For example, consider this `Contention`: 
`Contention( contention_text="barbeque 111-11-1111 rainbows", contention_type="NEW" )`

Let's assume the csv lookup will fail for this. With the change introduced by this PR, this will be representative of the log:
```
{ 
  'vagov_claim_id': 100, 
  'claim_type': 'new', 
  'classification_code': None,
  'classification_name': None,
  'contention_text': 'unmapped contention text',
  'diagnostic_code': 'None', 
   [...]
  'ml_sample': 'barbeque rainbows',     <--- this is the new field
}
```
Additionally, the value is scrubbed of numbers, as a precaution against logging identifiers such as social security numbers


### other considerations

Why not use the existing `contention_text` attribute?  This might throw off existing analytics or monitoring in Datadog; and the nature of the change is relatively small.