### PR TITLE
Stop logging 'ml_sample' for cases where the csv lookup did not determine a classification

### DIFF
--- a/src/python_src/util/logging_utilities.py
+++ b/src/python_src/util/logging_utilities.py
@@ -55,7 +55,7 @@ def log_expanded_contention_text(
         )
     # log none as the processed text if it is not in the LUT and leave unmapped contention text as is
     else:
-        logging_dict.update({"processed_contention_text": None, "ml_sample": processed_text})
+        logging_dict.update({"processed_contention_text": None})
 
     return logging_dict
 
@@ -69,7 +69,7 @@ def log_contention_stats(
 ) -> None:
     """
     Logs stats about each contention process by the classifier. This will maintain
-    compatibility with the existing datadog widgets.
+    compatability with the existing datadog widgets.
     """
     classification_code = classified_contention.classification_code or None
     classification_name = classified_contention.classification_name or None

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -191,7 +191,6 @@ def test_non_classified_contentions(mocked_func: Mock) -> None:
         "endpoint": "/expanded-contention-classification",
         "processed_contention_text": None,
         "classification_method": classified_by,
-        "ml_sample": "john acl tear",
     }
     mocked_func.assert_called_once_with(expected_log)
 
@@ -317,7 +316,6 @@ def test_contentions_with_pii(mocked_func: Mock) -> None:
             "endpoint": "/expanded-contention-classification",
             "processed_contention_text": None,
             "classification_method": classified_by,
-            "ml_sample": "dependent claim child",
         },
         {
             "vagov_claim_id": test_claim.claim_id,
@@ -332,7 +330,6 @@ def test_contentions_with_pii(mocked_func: Mock) -> None:
             "endpoint": "/expanded-contention-classification",
             "processed_contention_text": None,
             "classification_method": classified_by,
-            "ml_sample": "john doe acl tear",
         },
     ]
 
@@ -445,7 +442,6 @@ def test_full_logging_expanded_endpoint(mocked_func: Mock) -> None:
             "endpoint": "/expanded-contention-classification",
             "classification_method": classified_by,
             "processed_contention_text": None,
-            "ml_sample": "john doe acl tear",
         },
         {
             "vagov_claim_id": test_claim.claim_id,


### PR DESCRIPTION
## summary of changes

Reverts #115.

Why: concern that we might unintentionally leak PII. 
While it's true that the value logged is processed through previously-existing helper functions meant to remove PII-like elements, a key factor is that in other cases where this processed text is being logged, it is contingent on a classification being made - which provides assurance of the scope of the original value. Whereas we don't have that assurance in this case of using the processed value when the classification was not found.
