### PR TITLE
[draft] debug codeclimate CI error

### DIFF
--- a/.github/workflows/test-code.yml
+++ b/.github/workflows/test-code.yml
@@ -44,6 +44,7 @@ jobs:
         uses: paambaati/codeclimate-action@v9.0.0
         env:
           CC_TEST_REPORTER_ID: ${{secrets.CC_TEST_REPORTER_ID}}
+          debug: true
 
       - name: "Run Bandit security scan"
         run: poetry run bandit -c pyproject.toml -r src tests

--- a/src/python_src/util/sanitizer.py
+++ b/src/python_src/util/sanitizer.py
@@ -5,7 +5,7 @@ def sanitize_log(obj: Union[str, bool, int, None]) -> Union[str, bool, int]:
     """
     Removes all newlines and carriage returns from the input log statement. This
     prevents the CodeQL warning stemming from Log entries created from user input
-    https://codeql.github.com/codeql-query-help/go/go-log-injection/
+    https://codeql.github.com/codeql-query-help/go/go-log-injection/ 
     """
     if isinstance(obj, bool):
         sanitized_str = str(obj).replace("\r\n", "").replace("\n", "")


### PR DESCRIPTION
## summary

We're observing the same issue as described in https://github.com/paambaati/codeclimate-action/issues/803 .

This PR was an attempt to debug. 

We've since learned that the Code Climate API that our CI integration was dependent on was disabled on July 18. (https://docs.qlty.sh/migration/coverage) 

We'll need to make some adjustments in our CI configuration, but I think this PR is not on the right path. Closing!