### PR TITLE
Remove Code Climate dependency

### DIFF
--- a/.github/workflows/test-code.yml
+++ b/.github/workflows/test-code.yml
@@ -40,10 +40,5 @@ jobs:
       - name: "Run tests with coverage"
         run: poetry run pytest --cov=src --cov-report=xml --cov-report=term-missing
 
-      - name: "Upload coverage to Code Climate"
-        uses: paambaati/codeclimate-action@v9.0.0
-        env:
-          CC_TEST_REPORTER_ID: ${{secrets.CC_TEST_REPORTER_ID}}
-
       - name: "Run Bandit security scan"
         run: poetry run bandit -c pyproject.toml -r src tests

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 [![Build and Push to ECR](https://github.com/department-of-veterans-affairs/contention-classification-api/actions/workflows/build_and_push_to_ecr.yml/badge.svg?event=push)](https://github.com/department-of-veterans-affairs/contention-classification-api/actions/workflows/build_and_push_to_ecr.yml)
 [![Continuous Integration](https://github.com/department-of-veterans-affairs/contention-classification-api/actions/workflows/continuous-integration.yml/badge.svg)](https://github.com/department-of-veterans-affairs/contention-classification-api/actions/workflows/continuous-integration.yml)
-[![Maintainability](https://api.codeclimate.com/v1/badges/e48f6ba9d97c1ff3ecab/maintainability)](https://codeclimate.com/github/department-of-veterans-affairs/contention-classification-api/maintainability)
-[![Test Coverage](https://api.codeclimate.com/v1/badges/e48f6ba9d97c1ff3ecab/test_coverage)](https://codeclimate.com/github/department-of-veterans-affairs/contention-classification-api/test_coverage)
 [![Poetry](https://img.shields.io/endpoint?url=https://python-poetry.org/badge/v0.json)](https://python-poetry.org/)
 ![Python Version from PEP 621 TOML](https://img.shields.io/badge/Python-3.12-blue)
 [![security: bandit](https://img.shields.io/badge/security-bandit-yellow.svg)](https://github.com/PyCQA/bandit)


### PR DESCRIPTION
## Summary

Removes continuous integration step of uploading test coverage results to Code Climate. 
Why: it is dependent on the Code Climate API, which was [deprecated](https://docs.qlty.sh/migration/coverage) on July 18, 2025 .


Resolves https://github.com/department-of-veterans-affairs/vagov-claim-classification/issues/848.
Potential follow-up work in https://github.com/department-of-veterans-affairs/vagov-claim-classification/issues/849.
