### PR TITLE
update ML classifier logging

### DIFF
--- a/src/python_src/api.py
+++ b/src/python_src/api.py
@@ -90,7 +90,7 @@ def hybrid_classification(claim: VaGovClaim, request: Request) -> ClassifierResp
     if response.is_fully_classified:
         return response
 
-    response = supplement_with_ml_classification(response, claim)
+    response = supplement_with_ml_classification(response, claim, request)
 
     num_classified = len([c for c in response.contentions if c.classification_code])
     response.num_classified_contentions = num_classified

--- a/src/python_src/util/classifier_utilities.py
+++ b/src/python_src/util/classifier_utilities.py
@@ -113,7 +113,7 @@ def build_ai_request(response: ClassifierResponse, claim: VaGovClaim) -> tuple[l
 
 
 @log_ml_contention_stats_decorator
-def update_classifications(response: ClassifierResponse, indices: list[int], ai_classified: AiResponse) -> ClassifierResponse:
+def update_classifications(response: ClassifierResponse, indices: list[int], ai_classified: AiResponse, request: Request) -> ClassifierResponse:
     """
     Updates the originally classified claim with classifications from the ml classifier
     """
@@ -151,9 +151,9 @@ def ml_classify_claim(contentions: AiRequest) -> AiResponse:
     )
 
 
-def supplement_with_ml_classification(response: ClassifierResponse, claim: VaGovClaim) -> ClassifierResponse:
+def supplement_with_ml_classification(response: ClassifierResponse, claim: VaGovClaim, request: Request) -> ClassifierResponse:
     non_classified_indices, ai_request = build_ai_request(response, claim)
     ai_response = ml_classify_claim(ai_request)
-    response = update_classifications(response, non_classified_indices, ai_response)
+    response = update_classifications(response, non_classified_indices, ai_response, request)
 
     return response

--- a/src/python_src/util/classifier_utilities.py
+++ b/src/python_src/util/classifier_utilities.py
@@ -113,7 +113,8 @@ def build_ai_request(response: ClassifierResponse, claim: VaGovClaim) -> tuple[l
 
 
 @log_ml_contention_stats_decorator
-def update_classifications(response: ClassifierResponse, indices: list[int], ai_classified: AiResponse, request: Request) -> ClassifierResponse:
+def update_classifications(response: ClassifierResponse, indices: list[int],
+    ai_classified: AiResponse, request: Request) -> ClassifierResponse:
     """
     Updates the originally classified claim with classifications from the ml classifier
     """

--- a/src/python_src/util/logging_utilities.py
+++ b/src/python_src/util/logging_utilities.py
@@ -147,7 +147,7 @@ def log_contention_stats_decorator(
     return wrapper
 
 
-def log_ml_contention_stats(response: ClassifierResponse, ai_response: AiResponse) -> None:
+def log_ml_contention_stats(response: ClassifierResponse, ai_response: AiResponse, request: Request) -> None:
     """
     Logs stats about each contention processed by the ML classifier.
     """
@@ -179,7 +179,7 @@ def log_ml_contention_stats(response: ClassifierResponse, ai_response: AiRespons
             "is_in_dropdown": False,
             "is_lookup_table_match": False,
             "is_multi_contention": is_multi_contention,
-            "endpoint": "ML Classification Endpoint",
+            "endpoint": request.url.path,
             "classification_method": "ML Classification",
             "ml_classifier_version": ml_version,
         }
@@ -193,7 +193,8 @@ def log_ml_contention_stats_decorator(func: Callable[..., ClassifierResponse]) -
         result = func(*args, **kwargs)
         response = args[0]
         ai_response = args[2]
-        log_ml_contention_stats(response, ai_response)
+        request = args[3]
+        log_ml_contention_stats(response, ai_response, request)
         return result
 
     return wrapper

--- a/src/python_src/util/logging_utilities.py
+++ b/src/python_src/util/logging_utilities.py
@@ -191,10 +191,12 @@ def log_ml_contention_stats_decorator(func: Callable[..., ClassifierResponse]) -
     @wraps(func)
     def wrapper(*args: Any, **kwargs: Any) -> ClassifierResponse:
         result = func(*args, **kwargs)
-        response = args[0]
-        ai_response = args[2]
-        request = args[3]
-        log_ml_contention_stats(response, ai_response, request)
+        if (
+            (classifier_response := kwargs.get("response"))
+            and (ai_response := kwargs.get("ai_classified"))
+            and (request := kwargs.get("request"))
+        ):
+            log_ml_contention_stats(classifier_response, ai_response, request)
         return result
 
     return wrapper

--- a/src/python_src/util/logging_utilities.py
+++ b/src/python_src/util/logging_utilities.py
@@ -174,13 +174,13 @@ def log_ml_contention_stats(response: ClassifierResponse, ai_response: AiRespons
             "claim_type": sanitize_log(log_contention_type),
             "classification_code": classified_contention.classification_code,
             "classification_name": classified_contention.classification_name,
-            "contention_text": "FILTERED [ML Classification]",
+            "contention_text": "unmapped contention text",
             "diagnostic_code": classified_contention.diagnostic_code,
             "is_in_dropdown": False,
             "is_lookup_table_match": False,
             "is_multi_contention": is_multi_contention,
             "endpoint": request.url.path,
-            "classification_method": "ML Classification",
+            "classification_method": "ml_classifier",
             "ml_classifier_version": ml_version,
         }
 

--- a/tests/test_classifier_utilities.py
+++ b/tests/test_classifier_utilities.py
@@ -1,5 +1,8 @@
 from unittest.mock import MagicMock, call, patch
 
+from fastapi import Request
+from starlette.datastructures import Headers
+
 from src.python_src.pydantic_models import (
     AiRequest,
     AiResponse,
@@ -59,6 +62,14 @@ TEST_AI_REQUEST = AiRequest(
     ],
 )
 
+TEST_HYBRID_CLASSIFIER_REQUEST = Request(
+    scope={
+        "type": "http",
+        "method": "POST",
+        "path": "/hybrid-contention-classification",
+        "headers": Headers(),
+    }
+)
 
 def update_contentions_test(contentions: list[ClassifiedContention]) -> list[ClassifiedContention]:
     updated_contentions = []
@@ -117,7 +128,8 @@ def test_update_classifications() -> None:
         ]
     )
     test_indices = [1, 2]
-    expected = update_classifications(TEST_RESPONSE, test_indices, test_ai_response)
+
+    expected = update_classifications(TEST_RESPONSE, test_indices, test_ai_response, TEST_HYBRID_CLASSIFIER_REQUEST)
     for idx in test_indices:
         assert expected.contentions[idx].classification_code == 9999
         assert expected.contentions[idx].classification_name == "ml classification"
@@ -149,6 +161,7 @@ def test_update_classifications_logs_mismatch(mocked_func: MagicMock) -> None:
             2,
         ],
         test_ai_response,
+        TEST_HYBRID_CLASSIFIER_REQUEST
     )
     mocked_func.assert_called_once_with({"message": "Mismatched contentions between AiResponse and original classifications"})
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -551,13 +551,13 @@ def test_ml_classification_logging(mock_log: Mock) -> None:
         "claim_type": "new",
         "classification_code": 9999,
         "classification_name": "ML Classified",
-        "contention_text": "FILTERED [ML Classification]",
+        "contention_text": "unmapped contention text",
         "diagnostic_code": None,
         "is_in_dropdown": False,
         "is_lookup_table_match": False,
         "is_multi_contention": True,
         "endpoint": "/hybrid-contention-classification",
-        "classification_method": "ML Classification",
+        "classification_method": "ml_classifier",
     }
 
     # Check that the function was called with logs containing the expected keys

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -29,6 +29,14 @@ test_expanded_request = Request(
     }
 )
 
+test_hybrid_request = Request(
+    scope={
+        "type": "http",
+        "method": "POST",
+        "path": "/hybrid-contention-classification",
+        "headers": Headers(),
+    }
+)
 
 def test_create_classification_method_new() -> None:
     """
@@ -537,7 +545,7 @@ def test_ml_classification_logging(mock_log: Mock) -> None:
         num_classified_contentions=1,
     )
     # call function
-    log_ml_contention_stats(response, test_AI_response)
+    log_ml_contention_stats(response, test_AI_response, test_hybrid_request)
     expected_logs = {
         "vagov_claim_id": 100,
         "claim_type": "new",
@@ -548,7 +556,7 @@ def test_ml_classification_logging(mock_log: Mock) -> None:
         "is_in_dropdown": False,
         "is_lookup_table_match": False,
         "is_multi_contention": True,
-        "endpoint": "ML Classification Endpoint",
+        "endpoint": "/hybrid-contention-classification",
         "classification_method": "ML Classification",
     }
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -504,6 +504,11 @@ def test_full_logging_expanded_endpoint(mocked_func: Mock) -> None:
 @patch("src.python_src.util.logging_utilities.ml_classifier")
 @patch("src.python_src.util.logging_utilities.log_as_json")
 def test_ml_classification_logging(mock_log: Mock, mock_ml_classifier: Mock) -> None:
+    """
+    Tests logging for ML-classified contentions
+    """
+    mock_ml_classifier.get_version.return_value = "v001"
+
     test_AI_response = AiResponse(
         classified_contentions=[
             ClassifiedContention(
@@ -547,11 +552,8 @@ def test_ml_classification_logging(mock_log: Mock, mock_ml_classifier: Mock) -> 
         num_classified_contentions=1,
     )
 
-    mock_ml_classifier.get_version.return_value = "v001"
-
-    # call function
     log_ml_contention_stats(response, test_AI_response, test_hybrid_request)
-    expected_logs = {
+    expected_log = {
         "vagov_claim_id": 100,
         "claim_type": "new",
         "classification_code": 9999,
@@ -571,6 +573,6 @@ def test_ml_classification_logging(mock_log: Mock, mock_ml_classifier: Mock) -> 
     actual_call_args = mock_log.call_args[0][0]
 
     # Verify all expected keys and values are present
-    for key, expected_value in expected_logs.items():
+    for key, expected_value in expected_log.items():
         assert key in actual_call_args, f"Expected key '{key}' not found in actual logs"
         assert actual_call_args[key] == expected_value, f"Expected {key}={expected_value}, got {actual_call_args[key]}"

--- a/tests/test_ml_classifier.py
+++ b/tests/test_ml_classifier.py
@@ -18,6 +18,9 @@ import os
 import string
 from unittest.mock import MagicMock, call, patch
 
+from fastapi import Request
+from starlette.datastructures import Headers
+
 import pytest
 from numpy import float32, ndarray
 from onnx.helper import make_node
@@ -436,7 +439,16 @@ def test_ml_classifier_logging_integration(mock_log: MagicMock, mock_ml_classifi
         ]
     )
 
-    log_ml_contention_stats(response, ai_response)
+    test_hybrid_classifier_request = Request(
+        scope={
+            "type": "http",
+            "method": "POST",
+            "path": "/hybrid-contention-classification",
+            "headers": Headers(),
+        }
+    )
+
+    log_ml_contention_stats(response, ai_response, test_hybrid_classifier_request)
 
     # Verify the function was called
     assert mock_log.called, "log_as_json should have been called"


### PR DESCRIPTION
## summary of changes

Updates the log payload for each ML-classified contention to be closer to the log payload for the contentions of the expanded classifier, to allow for extending to the ML classifier the datadog visualizations that were created for the expanded classifier.   related to https://github.com/department-of-veterans-affairs/va.gov-team/issues/116628 

changes to the log payload:
- report the request url (expected values: `/hybrid-contention-classification`, `/ml-contention-classification`) instead of  `ML Classification Endpoint`
-  report a `contention_text` value of `unmapped contention text` instead of `FILTERED [ML Classification]`
-  report a `classification_method` of `ml_classifier` instead of `ML Classification`

## implementation notes
- adds the `fastapi.Request` object as a parameter to methods related to the ML classification (why: so that the value of `request.url.path` can be included in the log payload), similar to the implementation of `def log_contention_stats()` ([link](https://github.com/department-of-veterans-affairs/contention-classification-api/blob/46e98c705525791b8623ab5d2cdbb10ade5233e9/src/python_src/util/logging_utilities.py#L61C7-L61C7)) that's used by the legacy expanded classifier.

- updates unit tests to separately test logging for multi-contention and single-contention claims that are routed to the ML classifier, and centralizes the tests for the contention logging to `test_logging.py`


## preview of the updated log payload

preview of the payload for a single-contention claim processed by the ML classifier:
https://github.com/department-of-veterans-affairs/contention-classification-api/blob/0b097a6605c565923d9ecc461805506b2f87fc38/tests/test_logging.py#L631-L645 


Examples of the log payload by the expanded classifier (that we seek to get closer to via this PR):
<img width="250"   alt="example1" src="https://github.com/user-attachments/assets/68eda640-70b2-45ce-9552-7aa16df1e155" />  <img width="250" alt="example2" src="https://github.com/user-attachments/assets/02cee118-5919-4d19-b007-de2f31a79c32" />


